### PR TITLE
Update monkey-patch to fix usage of `full_messages_for`

### DIFF
--- a/lib/rails/extensions/active_model.rb
+++ b/lib/rails/extensions/active_model.rb
@@ -1,31 +1,14 @@
 module ActiveModel
   class Errors
-    def full_messages
-      full_messages = []
-
-      each do |attribute, messages|
-        messages = Array.wrap(messages)
-        next if messages.empty?
-
-        if attribute == :base
-          messages.each {|m| full_messages << m }
-        else          
-          attr_name = attribute.to_s.gsub('.', '_').humanize
-          attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
-          options = { :default => "%{attribute} %{message}", :attribute => attr_name }
-
-          
-          messages.each do |m|
-            if m =~ /^\^/
-              full_messages << I18n.t(:"errors.format.full_message", options.merge(:message => m[1..-1], :default => "%{message}"))
-            else        
-              full_messages << I18n.t(:"errors.format", options.merge(:message => m))
-            end
-          end
-        end
+    def full_message(attribute, message)
+      return message if attribute == :base
+      attr_name = attribute.to_s.gsub('.', '_').humanize
+      attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+      if message =~ /^\^/
+        I18n.t(:"errors.format.full_message", options.merge(:message => m[1..-1], :default => "%{message}"))
+      else
+        I18n.t(:"errors.format", options.merge(:message => m))
       end
-
-      full_messages
     end
   end
 end

--- a/lib/rails/extensions/active_model.rb
+++ b/lib/rails/extensions/active_model.rb
@@ -4,6 +4,7 @@ module ActiveModel
       return message if attribute == :base
       attr_name = attribute.to_s.gsub('.', '_').humanize
       attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+      options = { :default => "%{attribute} %{message}", :attribute => attr_name }
       if message =~ /^\^/
         I18n.t(:"errors.format.full_message", options.merge(:message => m[1..-1], :default => "%{message}"))
       else

--- a/lib/rails/extensions/active_model.rb
+++ b/lib/rails/extensions/active_model.rb
@@ -6,9 +6,9 @@ module ActiveModel
       attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
       options = { :default => "%{attribute} %{message}", :attribute => attr_name }
       if message =~ /^\^/
-        I18n.t(:"errors.format.full_message", options.merge(:message => m[1..-1], :default => "%{message}"))
+        I18n.t(:"errors.format.full_message", options.merge(:message => message[1..-1], :default => "%{message}"))
       else
-        I18n.t(:"errors.format", options.merge(:message => m))
+        I18n.t(:"errors.format", options.merge(:message => message))
       end
     end
   end


### PR DESCRIPTION
Before this PR, the gem monkey-patched the main `full_messages` method, but misses other methods like `full_messages_for`.

Fix is to monkey-patch `full_message(attribute, message)` instead which is called in both `full_messages` and `full_messages_for` (see https://github.com/rails/rails/blob/4-2-stable/activemodel/lib/active_model/errors.rb#L377).
